### PR TITLE
Notebook selects correct kernel on JupyterTem

### DIFF
--- a/channel_calibration.ipynb
+++ b/channel_calibration.ipynb
@@ -29109,9 +29109,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:TFY4255]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-TFY4255-py"
   },
   "language_info": {
    "codemirror_mode": {


### PR DESCRIPTION
Hei, legg inn denne for at notebooken automatisk vil velje korrekt kernel på JupyterTem sida.
Du vi kanskje merge inn denne heilt på slutten, for det er lett å overskrive når ein jobbar på notebooken.